### PR TITLE
Allow using token

### DIFF
--- a/lib/gemonames.rb
+++ b/lib/gemonames.rb
@@ -7,36 +7,17 @@ module Gemonames
   module_function
   BASE_API_URL = "http://api.geonames.org"
 
-  def client(username: nil, connection: nil, token: nil)
-    connection ||=
-      if token
-        build_connection_using_token(token: token)
-      elsif username
-        build_connection_using_username(username: username)
-      else
-        fail "username or token needs to be defined to build a client"
-      end
-
+  def client(username:, connection: nil, token: nil)
+    connection ||= build_connection(username: username, token: token)
     ApiClient.new(connection)
   end
 
-  def build_connection_using_username(username:)
-    build_connection do |faraday|
-      faraday.params[:username] = username
-    end
-  end
-
-  def build_connection_using_token(token:)
-    build_connection do |faraday|
-      faraday.params[:token] = token
-    end
-  end
-
-  def build_connection
+  def build_connection(username:, token:)
     Faraday.new(url: BASE_API_URL) do |faraday|
       faraday.response :json
       faraday.adapter Faraday.default_adapter
-      yield(faraday)
+      faraday.params[:username] = username
+      faraday.params[:token] = token if token
     end
   end
 

--- a/spec/gemonames_spec.rb
+++ b/spec/gemonames_spec.rb
@@ -3,23 +3,6 @@ require "spec_helper"
 describe Gemonames do
   let(:client) { Gemonames.client(username: "demo") }
 
-  describe "token authentication" do
-
-    it "builds connection using username" do
-      expect(Gemonames).to receive(:build_connection_using_username).with(username: "demo")
-      client
-    end
-
-    context "with token" do
-      let(:client) { Gemonames.client(username: "demo", token: "abc") }
-
-      it "prefers token authentication" do
-        expect(Gemonames).to receive(:build_connection_using_token).with(token: "abc")
-        client
-      end
-    end
-  end
-
   describe "#search" do
     it "performs a search based on city and country code" do
       results = VCR.use_cassette "search-city-and-country-code" do


### PR DESCRIPTION
Before only username was supported to build a client
Geonames also provides token authentication and this change allows to
use token to build client

_username_ is always required
