### PR TITLE
Revert "Default to empty results when geonames key missing"

### DIFF
--- a/lib/gemonames.rb
+++ b/lib/gemonames.rb
@@ -35,7 +35,7 @@ module Gemonames
     def search(query, country_code:, limit: 10)
       perform_search_request(
         query: query, country_code: country_code, max_rows: limit
-      ).fetch("geonames") { [] }.map { |result|
+      ).fetch("geonames").map { |result|
         wrap_in_search_result(result)
       }
     end
@@ -43,7 +43,7 @@ module Gemonames
     def find(query, country_code:)
       results = perform_search_request(
         query: query, country_code: country_code, max_rows: 1
-      ).fetch("geonames") { [] }
+      ).fetch("geonames")
 
       if results.any?
         wrap_in_search_result(results.first)

--- a/spec/gemonames_spec.rb
+++ b/spec/gemonames_spec.rb
@@ -33,20 +33,6 @@ describe Gemonames do
       expect(results).to be_empty
     end
 
-    it "returns empty result when http response not successful" do
-      connection = double "connection",
-        get: instance_double(
-          "Faraday::Response",
-          env: { status: 400 },
-          body: {}
-      )
-      client = Gemonames.client(username: "demo", connection: connection)
-
-      results = client.search("query", country_code: "si")
-
-      expect(results).to be_empty
-    end
-
     it "does logging when provided with a logger" do
       log_output = StringIO.new
       client = Gemonames.client(
@@ -91,20 +77,6 @@ describe Gemonames do
       result = VCR.use_cassette "find-no-result" do
         client.find("UnknownPlace", country_code: "si")
       end
-
-      expect(result.result?).to be_falsey
-    end
-
-    it "returns empty result when http response not successful" do
-      connection = double "connection",
-        get: instance_double(
-          "Faraday::Response",
-          env: { status: 400 },
-          body: {}
-      )
-      client = Gemonames.client(username: "demo", connection: connection)
-
-      result = client.find("query", country_code: "si")
 
       expect(result.result?).to be_falsey
     end


### PR DESCRIPTION
Reverts Leadformance/gemonames#6 for now as it would lead to empty responses being cached.
