### PR TITLE
Use premium endpoint when configured with a token

### DIFF
--- a/lib/gemonames.rb
+++ b/lib/gemonames.rb
@@ -6,7 +6,9 @@ require "gemonames/response_logger"
 
 module Gemonames
   module_function
-  BASE_API_URL = "http://api.geonames.org"
+
+  FREE_ENDPOINT = "http://api.geonames.org"
+  PREMIUM_ENDPOINT = "http://ws.geonames.net"
 
   def client(username:, connection: nil, token: nil, logger: nil)
     connection ||= build_connection(
@@ -16,7 +18,8 @@ module Gemonames
   end
 
   def build_connection(username:, token:, logger:)
-    Faraday.new(url: BASE_API_URL) do |faraday|
+    url = token ? PREMIUM_ENDPOINT : FREE_ENDPOINT
+    Faraday.new(url: url) do |faraday|
       faraday.response :json
       faraday.use ResponseLogger, logger if logger
       faraday.adapter Faraday.default_adapter

--- a/spec/gemonames_spec.rb
+++ b/spec/gemonames_spec.rb
@@ -99,4 +99,22 @@ describe Gemonames do
       )
     end
   end
+
+  it "uses free endpoint when initialized without token" do
+    connection = Gemonames.build_connection(
+      username: "demo",
+      token: nil,
+      logger: nil,
+    )
+    expect(connection.url_prefix).to eq(URI("http://api.geonames.org"))
+  end
+
+  it "uses premium endpoint when initialized with a token" do
+    connection = Gemonames.build_connection(
+      username: "demo",
+      token: "immaginary-demo-token",
+      logger: nil,
+    )
+    expect(connection.url_prefix).to eq(URI("http://ws.geonames.net"))
+  end
 end


### PR DESCRIPTION
It turned out that even if a token was provided, the client would still hit the free service tier.

In order to use the premium service we have to use a different endpoint (`ws.geonames.net`).

With this change our requests will start showing up in the dashboard.

![2015-12-28 at 08 41](https://cloud.githubusercontent.com/assets/3621/12015588/dfb4ebde-ad3e-11e5-9b2b-84167f24a822.png)
