### PR TITLE
Bump version

### DIFF
--- a/lib/gemonames/version.rb
+++ b/lib/gemonames/version.rb
@@ -1,3 +1,3 @@
 module Gemonames
-  VERSION = "0.1.0"
+  VERSION = "0.2.0"
 end


### PR DESCRIPTION
it seems like server is confused and still tries to use older version of the gem as I'm getting `undefined class/module Gemonames::NoResultFound (ArgumentError)` and this class has been removed
