### PR TITLE
Raise ApiError for exceptions from Geonames

### DIFF
--- a/lib/gemonames/version.rb
+++ b/lib/gemonames/version.rb
@@ -1,3 +1,3 @@
 module Gemonames
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end

--- a/spec/cassettes/search-with-missing-parameters.yml
+++ b/spec/cassettes/search-with-missing-parameters.yml
@@ -1,0 +1,36 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://api.geonames.org/searchJSON?country&maxRows=1&q&style=full&username=there-is-no-chance-this-client-exists
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      date:
+      - Fri, 08 Jan 2016 11:40:13 GMT
+      server:
+      - Apache/2.4.6 (Linux/SUSE)
+      cache-control:
+      - no-cache
+      access-control-allow-origin:
+      - "*"
+      content-length:
+      - '56'
+      connection:
+      - close
+      content-type:
+      - application/json;charset=UTF-8
+    body:
+      encoding: UTF-8
+      string: '{"status":{"message":"user does not exist.","value":10}}'
+    http_version: 
+  recorded_at: Fri, 08 Jan 2016 11:40:13 GMT
+recorded_with: VCR 2.9.3

--- a/spec/gemonames/api_client_spec.rb
+++ b/spec/gemonames/api_client_spec.rb
@@ -106,5 +106,21 @@ module Gemonames
         end
       end
     end
+
+    describe "#perfom" do
+      let(:client) { Gemonames.client(username: "there-is-no-chance-this-client-exists") }
+      it "raises ApiError when api responds with 'status' key" do
+        VCR.use_cassette "search-with-missing-parameters" do
+          expect{
+            client.perform(
+              :search,
+              query: nil,
+              country: nil,
+              maxRows: 1
+            )
+          }.to raise_error ApiError
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Previously there would be a `KeyError` when there is an exception returned from Geonames API.

This change follows the exception handling documentation: http://www.geonames.org/export/webservice-exception.html
