### PR TITLE
Geonames country_code, country_name and timezone_id in timezone requests might not appear in response

### DIFF
--- a/lib/gemonames/api_client.rb
+++ b/lib/gemonames/api_client.rb
@@ -188,17 +188,16 @@ module Gemonames
 
     TIMEZONE_MAPPING = {
       optional: {
+        country_code: "countryCode".freeze,
+        country_name: "countryName".freeze,
+        timezone_id: "timezoneId".freeze,
       },
       required: {
-        country_code: "countryCode".freeze,
         gmt_offset: "gmtOffset".freeze,
         raw_offset: "rawOffset".freeze,
         dst_offset: "dstOffset".freeze,
         latitude: "lat".freeze,
         longitude: "lng".freeze,
-        country_name: "countryName".freeze,
-        timezone_id: "timezoneId".freeze,
-
       }
     }
   end


### PR DESCRIPTION
Geonames have inconsistent API response for successful timezone search

```
$ curl http://api.geonames.org/timezoneJSON?lat=0.0&lng=0.0&username=demo
*   Trying 5.9.152.54...
* Connected to api.geonames.org (5.9.152.54) port 80 (#0)
> GET /timezoneJSON?lat=0.0&lng=0.0&username=leadformance HTTP/1.1
> Host: api.geonames.org
> User-Agent: curl/7.43.0
> Accept: */*
>
< HTTP/1.1 200 OK
< Date: Fri, 30 Sep 2016 13:16:17 GMT
< Server: Apache/2.2.15 (CentOS)
< Cache-Control: no-cache
< Access-Control-Allow-Origin: *
< Content-Length: 59
< Connection: close
< Content-Type: application/json;charset=UTF-8
<
* Closing connection 0
{"lng":0,"gmtOffset":0,"rawOffset":0,"dstOffset":0,"lat":0}
```

Is a 200

```
curl -v "http://api.geonames.org/timezoneJSON?lat=20&lng=57&username=demo"
*   Trying 176.9.39.79...
* Connected to api.geonames.org (176.9.39.79) port 80 (#0)
> GET /timezoneJSON?lat=20&lng=57&username=demo HTTP/1.1
> Host: api.geonames.org
> User-Agent: curl/7.43.0
> Accept: */*
>
< HTTP/1.1 200 OK
< Date: Fri, 30 Sep 2016 13:18:23 GMT
< Server: Apache/2.4.6 (CentOS) mod_jk/1.2.41 OpenSSL/1.0.1e-fips
< Cache-Control: no-cache
< Access-Control-Allow-Origin: *
< Transfer-Encoding: chunked
< Content-Type: application/json;charset=UTF-8
<
* Connection #0 to host api.geonames.org left intact
{"sunrise":"2016-09-30 06:02","lng":57,"countryCode":"OM","gmtOffset":4,"rawOffset":4,"sunset":"2016-09-30 18:00","timezoneId":"Asia/Muscat","dstOffset":4,"countryName":"Oman","time":"2016-09-30 17:18","lat":20}
```

also

So we have 

```
{
   "sunset" : "2016-09-30 18:00",
   "timezoneId" : "Asia/Muscat",
   "countryCode" : "OM",
   "dstOffset" : 4,
   "gmtOffset" : 4,
   "lat" : 20,
   "rawOffset" : 4,
   "countryName" : "Oman",
   "sunrise" : "2016-09-30 06:02",
   "time" : "2016-09-30 17:18",
   "lng" : 57
}
```

and 

```
{
   "dstOffset" : 0,
   "gmtOffset" : 0,
   "lng" : 0,
   "lat" : 0,
   "rawOffset" : 0
}
```

are successful response

So 

```
sunset
timezoneId
countryCode
countryName
sunrise
time
```

are optional fields
